### PR TITLE
更改了rocketMQ专有属性内的描述，增加了容易忽视的rmq开启acl后的签名字段配置

### DIFF
--- a/通用组件/semak-stream.md
+++ b/通用组件/semak-stream.md
@@ -225,11 +225,35 @@ spring:
 
 
 #### 4.3.3. RocketMQ专有属性
-`spring.cloud.stream.rocketmq.bindings.<channelName>`节点下的属性为Kafka中间件特有的属性配置，主要分为**消费者属性**和**生产者属性**。
+`spring.cloud.stream.rocketmq.bindings.<channelName>`节点下的属性为RocketMQ中间件特有的属性配置，主要分为**消费者属性**和**生产者属性**。
 
 - [消费者属性](https://github.com/alibaba/spring-cloud-alibaba/wiki/RocketMQ#rocketmq-consumer-properties)
 - [生产者属性](https://github.com/alibaba/spring-cloud-alibaba/wiki/RocketMQ#rocketmq-provider-properties)
 
+> 当RocketMQ集群开启了`权限控制(acl)`后，需要在`binder`中添加`AccessKey`和`SecretKey`，可参考下方配置：
+
+```yaml
+spring:
+  cloud:
+    stream:
+      binders:
+        bizRocketmq:
+          type: rocketmq
+          defaultCandidate: true
+          environment:
+            spring:
+              cloud:
+                stream:
+                  rocketmq:
+                    binder:
+                      name-server: xx.xx.xx.xx:xx
+                      enable-msg-trace: true
+                      customized-trace-topic: xx
+                      # 看以下几行即可
+                      # 如果rocketMQ开启了acl，请务必配置开启下方配置，具体值请联系rocketmq中间件负责人
+                      # access-key: xx
+                      # secret-key: xx
+```
 
 
 ## 5. 使用方式


### PR DESCRIPTION
rocketmq集群开启acl，配套文档中为对开启acl后的签名字段未做**显示**的描述，需要跳转至官方文档才可以看到，读者容易忽略导致使用出问题，故补充文档。